### PR TITLE
Enclose only code blocks

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -23,10 +23,9 @@ echo "Biome $("$(npm root)"/.bin/biome --version)"
 echo '::group:: Running Biome with reviewdog 🐶 ...'
 # shellcheck disable=SC2016,SC2086
 "$(npm root)"/.bin/biome ci --max-diagnostics=30 ${INPUT_BIOME_FLAGS} 2>&1 1>/dev/null |
-  sed -z 's/\n \( × [^\n]*\)\n  \n/\1\n ```\n/g' |
-  sed -z 's/\n  \n\n/\n ```\n/g' |
-  sed 's/^$/ ```/' |
-  sed -z 's/```\n ```//g' |
+  sed 's/ *$//' |
+  sed -z 's/\n\n\([^\n]*│[^\n]*\)/\n ```\n\1/g' |
+  sed -z 's/│\n\n/│\n ```\n/g' |
   reviewdog \
     -efm="%-G%f ci ━%#" \
     -efm="%-G%f lint ━%#" \

--- a/script.sh
+++ b/script.sh
@@ -24,16 +24,16 @@ echo '::group:: Running Biome with reviewdog 🐶 ...'
 # shellcheck disable=SC2016,SC2086
 "$(npm root)"/.bin/biome ci --max-diagnostics=30 ${INPUT_BIOME_FLAGS} 2>&1 1>/dev/null |
   sed 's/ *$//' |
-  sed -z 's/\n\n\([^\n]*│[^\n]*\)/\n ```\n\1/g' |
-  sed -z 's/│\n\n/│\n ```\n/g' |
+  sed -z 's/\n\n\([^\n]*│[^\n]*\)/\n  ```\n\1/g' |
+  sed -z 's/│\n\n/│\n  ```\n/g' |
   reviewdog \
     -efm="%-G%f ci ━%#" \
     -efm="%-G%f lint ━%#" \
     -efm="%-Gci ━%#" \
     -efm="%E%f:%l:%c %.%#" \
     -efm="%E%f %.%#" \
-    -efm="%C × %m" \
-    -efm="%C %m" \
+    -efm="%C  × %m" \
+    -efm="%C  %m" \
     -efm="%-G%.%#" \
     -name="${INPUT_TOOL_NAME}" \
     -reporter="${INPUT_REPORTER}" \

--- a/script.sh
+++ b/script.sh
@@ -24,7 +24,7 @@ echo '::group:: Running Biome with reviewdog 🐶 ...'
 # shellcheck disable=SC2016,SC2086
 "$(npm root)"/.bin/biome ci --max-diagnostics=30 ${INPUT_BIOME_FLAGS} 2>&1 1>/dev/null |
   sed 's/ *$//' |
-  sed -z 's/\n\n\([^\n]*│[^\n]*\)/\n  ```\n\1/g' |
+  sed -z 's/\n\n\([^\n]*│[^\n]*\)/\n\n  ```\n\1/g' |
   sed -z 's/│\n\n/│\n  ```\n/g' |
   reviewdog \
     -efm="%-G%f ci ━%#" \
@@ -32,6 +32,7 @@ echo '::group:: Running Biome with reviewdog 🐶 ...'
     -efm="%-Gci ━%#" \
     -efm="%E%f:%l:%c %.%#" \
     -efm="%E%f %.%#" \
+    -efm="%C" \
     -efm="%C  × %m" \
     -efm="%C  %m" \
     -efm="%-G%.%#" \


### PR DESCRIPTION
Simplify the sed command to enclose only code blocks.