### PR TITLE
Fix `cannot open lib/biome.sh: No such file`

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -8,6 +8,9 @@ jobs:
   test-check:
     name: runner / Biome (github-check)
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      checks: write
     steps:
       - uses: actions/checkout@v4
       - name: action-success-test

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -8,10 +8,6 @@ jobs:
   test-check:
     name: runner / Biome (github-check)
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      checks: write
-      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: action-success-test

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       pull-requests: write
       checks: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: action-success-test

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -9,7 +9,7 @@ jobs:
     name: runner / Biome (github-check)
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: read
+      pull-requests: write
       checks: write
     steps:
       - uses: actions/checkout@v4

--- a/script.sh
+++ b/script.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 set -e
 
-. lib/biome.sh
+SCRIPT_DIR=$(cd $(dirname "$0") && pwd)
+
+. "${SCRIPT_DIR}/lib/biome.sh"
 
 if [ -n "${GITHUB_WORKSPACE}" ]; then
   cd "${GITHUB_WORKSPACE}/${INPUT_WORKDIR}" || exit

--- a/script.sh
+++ b/script.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-SCRIPT_DIR=$(cd $(dirname "$0") && pwd)
+SCRIPT_DIR=$(dirname "$0")
 
 . "${SCRIPT_DIR}/lib/biome.sh"
 


### PR DESCRIPTION
Fix this error when I use workdir

```
Run $GITHUB_ACTION_PATH/script.sh
  $GITHUB_ACTION_PATH/script.sh
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    WORKING_DIRECTORY: cdk
    SSH_KEY: ***
  
    PNPM_HOME: /home/runner/setup-pnpm/node_modules/.bin
    INPUT_GITHUB_TOKEN: ***
    INPUT_WORKDIR: cdk
    INPUT_TOOL_NAME: Biome
    INPUT_LEVEL: warning
    INPUT_REPORTER: github-pr-review
    INPUT_FILTER_MODE: nofilter
    INPUT_FAIL_ON_ERROR: true
    INPUT_REVIEWDOG_FLAGS: 
    INPUT_BIOME_FLAGS: .
/home/runner/work/_actions/mongolyy/reviewdog-action-biome/v1/script.sh: 4: .: cannot open lib/biome.sh: No such file
```