### PR TITLE
Scan test directory by renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,5 +4,8 @@
   ],
   "labels": [
     "bump:patch"
+  ],
+  "ignorePaths": [
+    "**/node_modules/**"
   ]
 }


### PR DESCRIPTION
With the current base configuration, the following directories are ignored.
```
{
  "ignorePaths": [
    "**/node_modules/**",
    "**/bower_components/**",
    "**/vendor/**",
    "**/examples/**",
    "**/__tests__/**",
    "**/test/**",
    "**/tests/**",
    "**/__fixtures__/**"
  ]
}
```

As a result, the project's package.json in the test directory is ignored.
To set IgnorePaths explicitly so that the test directory is also included.