### PR TITLE
No label when updating npm package by renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,9 +2,6 @@
   "extends": [
     "config:base"
   ],
-  "labels": [
-    "bump:patch"
-  ],
   "ignorePaths": [
     "**/node_modules/**"
   ]


### PR DESCRIPTION
Package updates by renovate are often updates to the npm package in the test directory.

Since this update basically does not change the source code, it is not released.
Therefore, labels are not automatically assigned.