### PR TITLE
Tags with suffixes will not be released

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
       - main
     tags:
       - "v*.*.*"
+      - "!v*.*.*-*"
   pull_request:
     types:
       - labeled


### PR DESCRIPTION
If we add a suffix with a tag, do not run the release action.
For example, if you add a tag like v1.6.0-beta, the v1 and v1.6 releases should not be executed