### PR TITLE
Set required input for setup-biome

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -54,6 +54,7 @@ runs:
       uses: biomejs/setup-biome@v2.2.1
       with:
         token: ${{ inputs.github_token }}
+        version: ''
         working-dir: ${{ inputs.workdir }}
     - uses: reviewdog/action-setup@v1.3.0
       with:


### PR DESCRIPTION
The version was required as input for the setup-biome action.
But because it was not set, a warning was displayed in the IDE.

As with the default value for the setup-biome action, I set an empty string as input.
https://github.com/biomejs/setup-biome/blob/v2.2.1/action.yaml#L12-L15