### PR TITLE
Restore the default value for `fail_on_error`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,8 +39,10 @@ inputs:
   fail_on_error:
     description: |
       Exit code for reviewdog when errors are found [true,false].
+      Default is `false` (temporary solution for #79).
     deprecationMessage: Deprecated. Use `fail_level` instead.
     required: false
+    default: 'false'
   reviewdog_flags:
     description: 'Additional reviewdog flags.'
     required: false


### PR DESCRIPTION
fix #79

This tool uses [reviewdog/action-suggester](https://github.com/reviewdog/action-suggester).
The `action-suggester` is not supported for `-fail-level` and we must continue to use `-fail-on-error`.

#79 has occurred because the default value setting for `-fail-on-error` was removed in #77.
In order to prioritize compatibility, the default value setting for `-fail-on-error` is temporarily reverted.

I think the `action-suggester` will be improved, and when it is improved, I will respond to #81.