### PR TITLE
Add fail_level option with action-suggester

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -86,6 +86,7 @@ runs:
         tool_name: ${{ inputs.tool_name }}
         level: ${{ inputs.level }}
         filter_mode: ${{ inputs.filter_mode }}
+        fail_level: ${{ inputs.fail_level }}
         fail_on_error: ${{ inputs.fail_on_error }}
         reviewdog_flags: ${{ inputs.reviewdog_flags }}
 


### PR DESCRIPTION
To adapt for reviewdog/action-suggester [v1.9.0](https://github.com/reviewdog/action-suggester/releases/tag/v1.19.0).
V1.9.0 supports `fail_level` option.
