### PR TITLE
Replace tagged version to hash pinned version for reviewdog/action-setup

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -63,7 +63,7 @@ runs:
         token: ${{ inputs.github_token }}
         version: ''
         working-dir: ${{ inputs.workdir }}
-    - uses: reviewdog/action-setup@v1.3.2
+    - uses: reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893 # v1.3.2
       with:
         reviewdog_version: v0.20.3
     - run: $GITHUB_ACTION_PATH/script.sh


### PR DESCRIPTION
## Description

In the action.yml file, reviewdog/action-setup was previously referenced using a tagged version. However, using a hash-pinned version is safer.

Additionally, the reviewdog/action-setup repository provides guidance on how to use a hash-pinned version in its documentation:
https://github.com/reviewdog/action-setup?tab=readme-ov-file#latest


## Summary by Github copilot
This pull request includes a small change to the `action.yml` file. The change updates the `reviewdog/action-setup` action to use a specific commit hash instead of a version tag.

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L66-R66): Updated `reviewdog/action-setup` to use commit hash `e04ffabe3898a0af8d0fb1af00c188831c4b5893` instead of version tag `v1.3.2`.