### PR TITLE
Multiple arguments passing to Biome

### DIFF
--- a/lib/biome.sh
+++ b/lib/biome.sh
@@ -7,7 +7,7 @@ biome_check() {
     exit 1
   fi
   # shellcheck disable=SC2086
-  biome check --colors=off --write $1 2>&1 1>/dev/null |
+  biome check --colors=off --write $@ 2>&1 1>/dev/null |
     sed 's/ *$//' |
     awk 'BEGIN { RS=""; ORS="\n\n" } { if (index($0, "│") > 0) { print "  ```\n" $0 "\n  ```" } else { print $0 } }'
 }
@@ -18,7 +18,7 @@ biome_ci() {
     exit 1
   fi
   # shellcheck disable=SC2086
-  biome ci --colors=off --max-diagnostics=30 $1 2>&1 1>/dev/null |
+  biome ci --colors=off --max-diagnostics=30 $@ 2>&1 1>/dev/null |
     sed 's/\x1B\[[0-9;]*[JKmsu]//g' |
     sed 's/✖/×/g' |
     sed 's/ℹ/i/g' |


### PR DESCRIPTION
Updated the `biome_check` and `biome_ci` function to correctly pass all arguments to the `biome` command.
This ensures that multiple arguments provided to `biome_flags` are properly forwarded.

The previous implementation (`$1`) only passed the first argument to `biome`, ignoring any additional arguments. Using `$@` expands to all positional parameters, preserving multi-argument functionality.

```bash
# Before: Only "arg1" was passed
# biome_flags: --changed --since=REF
biome check --colors=off --write --changed 2>&1 1>/dev/null

# After: All arguments are passed
# biome_flags: --changed --since=REF
biome check --colors=off --write --changed --since=REF 2>&1 1>/dev/null
```