### PR TITLE
chore(renovate): add supply chain security settings

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,8 +1,17 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
   ],
   "ignorePaths": [
     "**/node_modules/**"
-  ]
+  ],
+  "pinDigests": true,
+  "minimumReleaseAge": "3 days",
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "labels": [
+      "security"
+    ]
+  }
 }


### PR DESCRIPTION
## Summary

- Add `pinDigests: true` to pin GitHub Actions and other dependencies to their exact SHA digest, preventing tag-mutable supply chain attacks
- Add `minimumReleaseAge: "3 days"` to avoid pulling in newly published packages immediately, giving time for malicious releases to be detected and yanked
- Enable `osvVulnerabilityAlerts: true` to detect vulnerabilities via the OSV database (broader coverage than GitHub Advisory Database alone)
- Add `vulnerabilityAlerts` with `security` label to distinguish security fix PRs from regular dependency updates
- Add `$schema` for configuration validation

## Test plan

- [ ] Verify Renovate runs successfully after merging
- [ ] Confirm that new dependency update PRs include SHA digests (e.g. for GitHub Actions)
- [ ] Confirm that vulnerability-related PRs are labeled `security`