### PR TITLE
fix: add explicit permissions to all GitHub Actions workflows

### DIFF
--- a/.github/workflows/depup.yml
+++ b/.github/workflows/depup.yml
@@ -6,6 +6,10 @@ on:
     types: [depup]
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   reviewdog:
     runs-on: ubuntu-latest

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -7,6 +7,10 @@ on:
     branches:
       - main
   workflow_dispatch:
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   label:
     name: Manage GitHub labels

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
   release:
     if: github.event.action != 'labeled'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -52,6 +54,9 @@ jobs:
   release-check:
     if: github.event.action == 'labeled'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Post bumpr status comment

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -4,6 +4,11 @@ on:
     branches:
       - main
   pull_request:
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
 jobs:
   shellcheck:
     name: runner / shellcheck

--- a/.github/workflows/test-shell.yml
+++ b/.github/workflows/test-shell.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - main
   pull_request:
+permissions:
+  contents: read
+
 jobs:
   shellspec:
     name: runner / ShellSpec


### PR DESCRIPTION
## Summary

- Addresses CodeQL code scanning alerts #41–#50 (`actions/missing-workflow-permissions`)
- Adds least-privilege `permissions` blocks to all workflow files that were missing them

| File | Permissions added |
|------|------------------|
| `test-shell.yml` | `contents: read` (workflow level) |
| `reviewdog.yml` | `contents: read`, `checks: write`, `pull-requests: write` (workflow level) |
| `release.yml` `release` job | `contents: write` (job level) |
| `release.yml` `release-check` job | `contents: read`, `pull-requests: write` (job level) |
| `depup.yml` | `contents: write`, `pull-requests: write` (workflow level) |
| `labels.yml` | `contents: read`, `issues: write` (workflow level) |

## Test plan

- [x] Confirm CI passes on this PR
- [ ] Confirm CodeQL alerts #41–#50 are closed after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)