### PR TITLE
Configure Renovate to enforce minimum release age for npm updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,10 +8,20 @@
   ],
   "pinDigests": true,
   "minimumReleaseAge": "3 days",
+  "internalChecksFilter": "strict",
   "osvVulnerabilityAlerts": true,
   "vulnerabilityAlerts": {
     "labels": [
       "security"
     ]
-  }
+  },
+  "packageRules": [
+    {
+      "description": "Bump versions in package.json instead of lockfile-only updates so minimumReleaseAge (3 days) is enforced. In-range update-lockfile updates bypass the stability check.",
+      "matchManagers": [
+        "npm"
+      ],
+      "rangeStrategy": "bump"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
Updated Renovate configuration to enforce the 3-day minimum release age stability check for npm package updates by using the `bump` range strategy instead of allowing lockfile-only updates.

## Changes
- Added `"internalChecksFilter": "strict"` to enable stricter internal checks
- Added `packageRules` configuration for npm manager with `"rangeStrategy": "bump"` to ensure version bumps in package.json rather than lockfile-only updates, which allows the `minimumReleaseAge` (3 days) stability check to be properly enforced
- Added descriptive comment explaining the rationale for the package rule

## Details
Previously, Renovate could perform lockfile-only updates that would bypass the 3-day minimum release age stability check. This change ensures that npm updates bump versions in package.json, making them subject to the stability requirements configured in the Renovate settings.

https://claude.ai/code/session_01NWAFpio7GnC1dbtb6GL51M